### PR TITLE
React elements set CSS classes via className prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,18 +219,18 @@ Instead, you should be using some sort of **HTML templates**. Rails has partials
 
 ```js
 const ItemCard = ({ name, price, image, description, alt }) => (
-  <article class="br2 ba dark-gray b--black-10 mv4 w-100 w-50-m w-25-l mw5 center">
-    <img src={image} class="db w-100 br2 br--top" alt={alt}>
-    <div class="pa2 ph3-ns pb3-ns">
-      <div class="dt w-100 mt1">
-        <div class="dtc">
-          <h1 class="f5 f4-ns mv0">{name}</h1>
+  <article className="br2 ba dark-gray b--black-10 mv4 w-100 w-50-m w-25-l mw5 center">
+    <img src={image} className="db w-100 br2 br--top" alt={alt}>
+    <div className="pa2 ph3-ns pb3-ns">
+      <div className="dt w-100 mt1">
+        <div className="dtc">
+          <h1 className="f5 f4-ns mv0">{name}</h1>
         </div>
-        <div class="dtc tr">
-          <h2 class="f5 mv0">{price}</h2>
+        <div className="dtc tr">
+          <h2 className="f5 mv0">{price}</h2>
         </div>
       </div>
-      <p class="f6 lh-copy measure mt2 mid-gray">{description}</p>
+      <p className="f6 lh-copy measure mt2 mid-gray">{description}</p>
     </div>
   </article>
 )


### PR DESCRIPTION
In order for a React JSX element to assign classes to an underlying DOM element, one should supply a `className` property. With a React JSX element, supplying the property `class` is a no-op.

So supplying a `class` prop is wrong.